### PR TITLE
Fix hashtag breaking over two lines

### DIFF
--- a/css/style-bosc.css
+++ b/css/style-bosc.css
@@ -621,11 +621,14 @@ tr:nth-child(1) {
 
 .bosc-footer-sub-section .networks {
     display: grid;
-    grid-template-columns: 25% 25% 25% 25%;
+    grid-template-columns: 24% 28% 24% 24%;
 }
 
 .network-item {
     text-align: center;
+    overflow-wrap: normal;
+    word-break: normal;
+    font-size: 16px;
 }
 
 @media only screen and (max-width: 1024px) {
@@ -858,6 +861,11 @@ tr:nth-child(1) {
         display: flex;
         flex-wrap: wrap-reverse;
     }
+
+    .bosc-footer-sub-section {
+        grid-template-columns: 100%;
+    }
+
 }
 
 @media only screen and (max-width: 480px) {


### PR DESCRIPTION
<img width="885" alt="image" src="https://user-images.githubusercontent.com/9271438/54495945-25c4b280-48e1-11e9-9463-7c275adc4100.png">

This is what it looks like on Chrome for me now - the issue never occurred on FF. We also break the footer buttons down to a new row at some narrower resolutions to cope with the issue: 

<img width="657" alt="image" src="https://user-images.githubusercontent.com/9271438/54495943-180f2d00-48e1-11e9-8ad3-787202a9eb2a.png">


It'll still wrap at really tiny screen resolutions (small / old phones) but I think that's reasonable .
