### PR TITLE
Timeline fix for links breaking lines

### DIFF
--- a/css/style-bosc.css
+++ b/css/style-bosc.css
@@ -331,7 +331,13 @@ ul.bosc-timeline li:before {
     margin-top: 10px;
 }
 
+
 ul.bosc-timeline li a {
+    display: inline;
+    font-weight: normal;
+}
+
+ul.bosc-timeline li a:nth-child(1) {
     display: block;
     font-size: 20px;
     font-weight: bold;


### PR DESCRIPTION
before all links were block links - now only the first one is. It looks like this: 
![image](https://user-images.githubusercontent.com/9271438/69582672-fd916580-0fd0-11ea-9770-842e4034d75f.png)
