### PR TITLE
Style tweaks

### DIFF
--- a/css/style-bosc.css
+++ b/css/style-bosc.css
@@ -226,6 +226,10 @@ p.bosc-overview {
     margin-bottom: 0;
 }
 
+.dates-sessions .wp-block-column {
+  flex-basis:50%;
+}
+
 .dates-sessions .important-dates,
 .bosc-committee .bosc-organizing-committee,
 .bosc-previous-and-contact .bosc-contact {
@@ -243,8 +247,8 @@ p.bosc-overview {
     margin-right: 0;
 }
 
-.important-dates ul li {
-    margin-bottom: 10px;
+.dates-sessions .session-topics h2, .dates-sessions .important-dates h2 {
+  margin-top:0.4em;
 }
 
 .wp-block-button__link {

--- a/css/style-bosc.css
+++ b/css/style-bosc.css
@@ -1027,4 +1027,8 @@ tr:nth-child(1) {
     .bosc-footer-sub-section {
         grid-template-columns: 100%;
     }
+
+    .dates-sessions .wp-block-column {
+      flex-basis:100%;
+    }
 }

--- a/style.css
+++ b/style.css
@@ -373,13 +373,14 @@ i {
 .news-section {
     background-color: #1b2e25;
     margin-top: 3%;
-    padding: 3% 2% 0 0;
+    padding: 2% 2% 2% 0;
     transition: 1s ease;
 }
 
 .news-section h1 {
     color: #88eef7;
     font-family: 'Montserrat', sans-serif;
+    margin-top:0;
 }
 
 .news-section img {


### PR DESCRIPTION
Fixes three small issues:

- homepage: read more button on the black section no longer runs into the bottom of the box
- bosc page : yellow/green sections were misaligned compared to the rest of the page
- bosc page - list items in the yellow vs green sections had different spacing. 

<img width="986" alt="image" src="https://user-images.githubusercontent.com/9271438/74983929-0d80e000-542e-11ea-8105-415b1da28597.png">
