### PR TITLE
Use get_the_date instead of the_date

### DIFF
--- a/home.php
+++ b/home.php
@@ -15,15 +15,15 @@
         </div>
 
         <!--first post-->
-        <?php 
+        <?php
         $obf_exclude = get_cat_ID('home');
 
         $q = '-'.$obf_exclude;
-        
+
         $paged = get_query_var( 'paged' ) ? get_query_var( 'paged' ) : 1;
-        
+
         $query = new WP_query ( array(
-            
+
             'posts_per_page' => 1,
             'cat' => $q,
             'post_type' => 'post',
@@ -45,7 +45,7 @@
                                     <?php the_title(); ?>
                                 </h1>
                                 <p class="date"> [
-                                    <?php the_date(); ?> ]</p>
+                                    <?php echo get_the_date('F j, Y'); ?> ]</p>
                                 <p>
                                     <?php the_excerpt(); ?>
                                 </p>
@@ -57,20 +57,20 @@
                 </div>
             </article>
             <?php } ?>
-            <?php endwhile; 
+            <?php endwhile;
                                      rewind_posts();
                                      ?>
-            <?php 
-                                     
+            <?php
+
                 wp_reset_postdata(); ?>
         </section>
 
         <?php } ?>
 
-        <?php 
+        <?php
         $obf_exclude = get_cat_ID('home');
         $q = '-'.$obf_exclude;
-        
+
         $paged = get_query_var( 'paged' ) ? get_query_var( 'paged' ) : 1;
         if ( $paged == 1 ){
       $offset=1;
@@ -85,7 +85,7 @@
             'offset' => $offset,
             'number_of_posts' => 15,
         ) );
-        
+
         if ( $query->have_posts() ) { ?>
         <section class="recent-posts grid-container">
             <?php while ( $query->have_posts() ) : $query->the_post(); ?>
@@ -107,7 +107,7 @@ the_post_thumbnail();
                                     <?php echo wp_trim_words( get_the_title(), 5 ); ?>
                                 </h1>
                                 <p class="date"> [
-                                    <?php the_date(); ?> ]</p>
+                                    <?php echo get_the_date('F j, Y'); ?> ]</p>
                                 <p>
                                     <?php the_excerpt(); ?>
                                 </p>
@@ -123,8 +123,8 @@ the_post_thumbnail();
             <?php endwhile;
                     rewind_posts(); ?>
 
-            <?php 
-                                     
+            <?php
+
                 wp_reset_postdata(); ?>
         </section>
 

--- a/tag.php
+++ b/tag.php
@@ -21,10 +21,10 @@
                 <?php the_title(); ?></a>
         </h2>
         <p>
-            <?php the_date(); ?> :
+            <?php echo get_the_date('F j, Y'); ?> :
             <?php the_excerpt(); ?>
         </p>
-        <?php endwhile;     
+        <?php endwhile;
             else: ?>
         <p>not working</p>
         <?php endif; ?>


### PR DESCRIPTION
This fixes #74

The fix is to use `get_the_date` and `echo` the result rather than `the_date` since the latter will only return a date once per day with the `query_posts` method, see [this answer](https://wordpress.stackexchange.com/a/52497) on WP stack exchange.

Please note, some of the changes in this PR are simple whitespace changes because my IDE automatically trims whitespace. 

Let me know if this is helpful!