### PR TITLE
fixed layout icons of BOSC footer

### DIFF
--- a/css/style-bosc.css
+++ b/css/style-bosc.css
@@ -639,10 +639,10 @@ tr:nth-child(1) {
 
 .bosc-footer-sub-section .networks {
     display: grid;
-    gap: 2px;
-    margin: 5px;
-    margin-left: 10px;
     grid-template-columns: 15% 15% 15% 15% 15% 15%;
+    margin-bottom: 5px;
+    margin: auto;
+    gap: 2px;
 }
 
 .network-item {

--- a/css/style-bosc.css
+++ b/css/style-bosc.css
@@ -639,7 +639,10 @@ tr:nth-child(1) {
 
 .bosc-footer-sub-section .networks {
     display: grid;
-    grid-template-columns: 18% 24% 18% 18% 18%;
+    gap: 2px;
+    margin: 5px;
+    margin-left: 10px;
+    grid-template-columns: 15% 15% 15% 15% 15% 15%;
 }
 
 .network-item {

--- a/css/style-bosc.css
+++ b/css/style-bosc.css
@@ -639,10 +639,12 @@ tr:nth-child(1) {
 
 .bosc-footer-sub-section .networks {
     display: grid;
-    grid-template-columns: 15% 15% 15% 15% 15% 15%;
-    margin-bottom: 5px;
-    margin: auto;
+    
+    margin-bottom: 10px;
+    grid-template-columns: repeat(6, 1fr);
     gap: 2px;
+    padding: 2px;
+    margin-left: auto;
 }
 
 .network-item {


### PR DESCRIPTION
updated the custom values of columns to   grid-template-columns: repeat(6, 1fr);
because , All 6 columns will have the same width, which is equal to 1/6 of the grid container's width. The fr unit makes the grid flexible, meaning that the columns will adjust their width based on the available space in the grid container. And The grid will automatically adapt to different screen sizes and orientations, as the columns will resize to fit the available space.


![Screenshot 2024-07-14 134703](https://github.com/user-attachments/assets/6e489fc7-bb58-4c78-b670-662db0515b35)
![Screenshot 2024-07-14 134625](https://github.com/user-attachments/assets/74efb362-db6d-4fec-bd52-29f41d171f8f)
