### PR TITLE
Move link to recent minutes

### DIFF
--- a/meeting-minutes.php
+++ b/meeting-minutes.php
@@ -10,12 +10,14 @@ Template Name: meeting minutes
 
 
     <div class="container-fluid">
-        <div>
-        <p></p>Starting in July 2019, OBF Board public meeting minutes can be found in
-            <a href="https://github.com/OBF/obf-docs/tree/master/minutes">our GitHub repository</a>.</p>
-        </div>
         <?php custom_breadcrumbs(); ?>
         <article>
+            <div>
+            <p>
+                Starting in July 2019, OBF Board public meeting minutes can be found in
+                <a href="https://github.com/OBF/obf-docs/tree/master/minutes">our GitHub repository</a>.
+            </p>
+            </div>
             <?php $query2 = new WP_Query( array( 'category_name' => 'meeting-minutes' ) ); ?>
             <?php if($query2->have_posts()) : ?>
             <?php while($query2->have_posts()) : $query2->the_post(); ?>


### PR DESCRIPTION
Follow up on #89. Fixes ``</p>`` and tries moving the div later.